### PR TITLE
Add println of hash for easier comparison with host

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ pub fn main() {
         }
     };
     let hash = B256::from(keccak(alloy_rlp::encode(header)));
+    println!("{}", hash);
     if let Err(e) = valida_rs::io::write(&hash) {
         println!("Error writing hash: {}", e);
     }


### PR DESCRIPTION
We seem to have some differences in handling the encoding compared to host when outputting to stdout as a byproduct of valida_rs::io::write, so adding a simple println before we write anything to the logfile so we can directly compare the actual result with a host execution of the same code.